### PR TITLE
Upper case column names before comparison

### DIFF
--- a/src/main/scala/org/finra/msd/sparkcompare/SparkCompare.scala
+++ b/src/main/scala/org/finra/msd/sparkcompare/SparkCompare.scala
@@ -140,9 +140,17 @@ object SparkCompare {
   private def compareSchemaDataFrames(left: DataFrame, leftViewName: String
                                       , right: DataFrame, rightViewName: String): Pair[DataFrame, DataFrame] = {
     //make sure that column names match in both dataFrames
-    if (!left.columns.sameElements(right.columns)) {
-      println("column names were different")
-      throw new Exception("Column Names Did Not Match")
+    val leftColumns = left.columns.clone()
+    val rightColumns = right.columns.clone()
+
+    for (i <- 0 to leftColumns.length - 1) {
+      leftColumns(i) = leftColumns(i).toUpperCase()
+      rightColumns(i) = rightColumns(i).toUpperCase()
+    }
+
+    if (!leftColumns.sameElements(rightColumns)) {
+      throw new Exception("Column Names Did Not Match\n" +
+        "column names were different\nLeft: " + left.columns.mkString(",") + "\nRight:" + right.columns.mkString(","))
     }
 
     val leftCols = left.columns.mkString(",")

--- a/src/main/scala/org/finra/msd/sparkcompare/SparkCompare.scala
+++ b/src/main/scala/org/finra/msd/sparkcompare/SparkCompare.scala
@@ -96,17 +96,17 @@ object SparkCompare {
 
     //Means one of them is not a schema data source and will flatten one of them
     var flatLeft: DataFrame = left.dataFrame
-    var flatright: DataFrame = right.dataFrame
+    var flatRight: DataFrame = right.dataFrame
 
     //if one of the inputs has no schema then will flatten it using the delimiter
     if (left.sourceType == SourceType.HIVE || left.sourceType == SourceType.JDBC)
       flatLeft = SparkFactory.flattenDataFrame(left.dataFrame , left.delimiter)
 
     if (right.sourceType == SourceType.HIVE || right.sourceType == SourceType.JDBC)
-      flatright = SparkFactory.flattenDataFrame(right.dataFrame , right.delimiter)
+      flatRight = SparkFactory.flattenDataFrame(right.dataFrame , right.delimiter)
 
     //COMPARE flatLeft to flatRight
-    return compareFlatDataFrames(flatLeft , flatright)
+    return compareFlatDataFrames(flatLeft , flatRight)
   }
 
   /**


### PR DESCRIPTION
Some formatting and cleanup
Convert the column names to upper case before comparing.
