### PR TITLE
Allow equal character in value part of data source config

### DIFF
--- a/src/main/java/org/finra/msd/containers/SourceVars.java
+++ b/src/main/java/org/finra/msd/containers/SourceVars.java
@@ -73,10 +73,10 @@ public class SourceVars
                        query = line.substring(line.indexOf(":")+1).trim();
                 queries.put(dataName,query);
             }
-            else if (line.contains("=") && line.indexOf("=") == line.lastIndexOf("="))
+            else if (line.contains("="))
             {
-                String key = line.substring(0,line.indexOf("=")).trim(),
-                       val = line.substring(line.indexOf("=")+1).trim();
+                String key = line.substring(0, line.indexOf("=")).trim();
+                String val = line.substring(line.indexOf("=") + 1).trim();
                 if (key.equals("connection"))
                     connection = val;
                 else


### PR DESCRIPTION
It's possible for JDBC URL of SQL Server to have equal character "=" as a part of it:

`jdbc:sqlserver://127.0.0.1:8157;database=FDR`

The code is changed to use the first equal as delimiter instead of ignoring the whole line when multiple equal presents in this PR.