### PR TITLE
Allow specifying delimiter in JDBC connection

### DIFF
--- a/src/main/java/org/finra/msd/launcher/Launcher.java
+++ b/src/main/java/org/finra/msd/launcher/Launcher.java
@@ -21,6 +21,7 @@ import org.finra.msd.containers.CmdLine;
 import org.finra.msd.containers.SourceVars;
 import org.finra.msd.sparkcompare.SparkCompare;
 import org.finra.msd.sparkfactory.SparkFactory;
+import scala.Option;
 
 import java.io.IOException;
 
@@ -70,7 +71,8 @@ public class Launcher {
                                     sv.getVar("user"),
                                     sv.getVar("password"),
                                     sv.getQuery(dataSetName),
-                                    tempViewName);
+                                    tempViewName,
+                                    Option.apply(sv.getVar("delimiter")));
             case "hive": return SparkFactory.parallelizeHiveSource(
                                     sv.getQuery(dataSetName),
                                     tempViewName);


### PR DESCRIPTION
Sometimes when comparing JDBC dataset with plain text files, other delimiters than commas are used in those text files. 

This PR allows specifying a different delimiter for JDBC connection so that such use cases can be covered.